### PR TITLE
Update to backtick-text-selector master code

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,3 @@
-// main.js
 module.exports = class BacktickTextSelector extends require('obsidian').Plugin {
     onload() {
         console.log("Loading backtick-text-selector");
@@ -7,6 +6,7 @@ module.exports = class BacktickTextSelector extends require('obsidian').Plugin {
 
     onunload() {
         console.log("Unloading backtick-text-selector");
+        // No specific unload actions needed
     }
 
     addCommands() {
@@ -41,42 +41,42 @@ module.exports = class BacktickTextSelector extends require('obsidian').Plugin {
 
     selectBacktickText(editor, direction) {
         const cursor = editor.getCursor();
-        const doc = editor.getDoc();
-        const cursorPos = doc.indexFromPos(cursor);
-        const regex = /`([^`]+)`/g;
-        let searchCursor;
+        const cursorOffset = editor.posToOffset(cursor);
+        const text = editor.getValue();
+
+        // Updated regex to match both inline code and code fences
+        const regex = /(`{1,3})([\s\S]*?[^`])\1/g;
+        let match;
+        const matches = [];
+
+        while ((match = regex.exec(text)) !== null) {
+            const backtickCount = match[1].length;
+            const startOffset = match.index + backtickCount;
+            const endOffset = match.index + match[0].length - backtickCount;
+            matches.push({ startOffset, endOffset });
+        }
+
+        let targetMatch = null;
 
         if (direction === 'next') {
-            searchCursor = editor.getSearchCursor(regex, cursor);
-            if (searchCursor.findNext()) {
-                let from = searchCursor.from();
-                let to = searchCursor.to();
-                // Adjust to exclude backticks
-                from.ch += 1;
-                to.ch -= 1;
-                editor.getDoc().setSelection(from, to);
-            }
+            targetMatch = matches.find(m => m.startOffset > cursorOffset);
         } else {
-            // For previous, we need to find all matches before the cursor
-            searchCursor = editor.getSearchCursor(regex, { line: 0, ch: 0 });
-            let lastMatch = null;
-            while (searchCursor.findNext()) {
-                if (doc.indexFromPos(searchCursor.to()) >= cursorPos) {
+            // For previous, find the last match before the cursor
+            for (let i = matches.length - 1; i >= 0; i--) {
+                if (matches[i].endOffset < cursorOffset) {
+                    targetMatch = matches[i];
                     break;
                 }
-                lastMatch = {
-                    from: searchCursor.from(),
-                    to: searchCursor.to(),
-                };
             }
-            if (lastMatch) {
-                let from = lastMatch.from;
-                let to = lastMatch.to;
-                // Adjust to exclude backticks
-                from.ch += 1;
-                to.ch -= 1;
-                editor.getDoc().setSelection(from, to);
-            }
+        }
+
+        if (targetMatch) {
+            const from = editor.offsetToPos(targetMatch.startOffset);
+            const to = editor.offsetToPos(targetMatch.endOffset);
+            editor.setSelection(from, to);
+        } else {
+            // Optional: Notify the user if no match is found
+            new Notice("No matching backtick text found.");
         }
     }
 };


### PR DESCRIPTION
I couldn't get backtick-text-selector to work on my side--it kept selecting the outer backticks when what I really wanted it to do was select the inside tick marks.  The code is what I came up with (with support of ChatGPT).  Let me know if this is the right direction. If no one else is having the issue, then it was me.