### PR TITLE
fix(README): correct keyboard shortcuts for text selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # backtick-text-selector
 
-This is a simple plugin that allows you to quickly select text that's inside `backticks` by pressing `Alt`-`` ` `` to select the next backtick text and `Alt`-`shift`-`` ` `` to select the previous backtick text.
+This is a simple plugin that allows you to quickly select text that's inside `backticks` by pressing `Alt`-`'` to select the next backtick text and `Alt`-`shift`-`'` to select the previous backtick text.


### PR DESCRIPTION
### What does this PR do?
This PR fixes the README file to correctly describe the keyboard shortcuts for the backtick-text-selector plugin.

The README incorrectly states that the shortcut is `Alt`-`` ` `` when it should be `Alt`-`'`. This PR updates the documentation to reflect the correct shortcuts.